### PR TITLE
Add AllNetAirtime API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ API | Description | Auth | HTTPS | CORS | Call this API |
 | [Absa Developer Portal](https://developer.absa.africa/static/home) | The Absa Access API Developer Portal is a framework that gives clients standardised, simplified and secure access to the bank’s services through a direct integration. | `OAuth` | Yes | Unknown | | 
 | [Adumo Online Developer](https://developers.adumoonline.com/) | Adumo Online provides an extensive resource centre enabling you to gain easy access to all the information required for a successful integration to any one of Adumo Online's payment solutions. | `Token` (JWT-Token) | Yes | Unknown | | 
 | [AfricanBank Bank API](https://api.grindrodbank.co.za/api/docs) | This is the African Bank API information page | `OAuth` and `OIDC` | Yes | Unknown | | 
+| [AllNetAirtime](https://allnetairtime.co.za/api/docs/) | Vendor API for South African universal airtime voucher registration, balances, and orders. | `apiKey` | Yes | No | | 
 | [Altcoin Trader API](https://www.altcointrader.co.za/api/) | The official API for AltcoinTrader. This allows you to get all the data for all the coins in one shot. | `OAuth` | Yes | Unknown | | 
 | [Bob Pay API](https://api-docs.bob.co.za/bobpay) | The Bob Pay API enables seamless integration with Bob Pay, allowing you to start accepting payments quickly and easily. | `apiKey` | Yes | Unknown | | 
 | [Commspace API](https://apidocs.commspace.co.za) | Commspace API to manage your commission and fees. | `apiKey` | Yes | Unknown | | 


### PR DESCRIPTION
## Summary
- add AllNetAirtime under the Finance section
- link to the public API documentation
- note auth as `apiKey`, HTTPS as `Yes`, and CORS as `No` based on live response headers

## Notes
- public docs: https://allnetairtime.co.za/api/docs/
- vendor registration is publicly documented and does not require authentication
- ordering and balance endpoints require an API key and a funded vendor account, so this is not an unrestricted anonymous API
- listed under Finance because the repo already groups voucher/payment APIs there