### PR TITLE
Add SuperSIM API

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ API | Description | Auth | HTTPS | CORS | Call this API |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [MTN Developer Portal](https://developers.mtn.com/) | List of product APIs for your business. | `X-API-KEY` | Yes | Unknown | 
+| [SuperSIM](https://supersim.co.za/api/docs) | SIM card management API for lookup, activation, swaps, usage, and wallet balances. | `X-API-TOKEN` | Yes | No | 
 | [Vodacom Pulse API](https://apipulse.vodacom.co.za/) | List of APIs for your business. | Unknown | Yes | Unknown | |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Summary
- add SuperSIM under the Telecommunications section
- link to the public API documentation
- note auth as `X-API-TOKEN`, HTTPS as `Yes`, and CORS as `No` based on live response headers

## Notes
- public docs: https://supersim.co.za/api/docs
- the documented API is for SIM lookup, activation, swaps, usage, and wallet balance
- endpoints are not anonymous: the OpenAPI spec declares global `X-API-TOKEN` auth for customer/reseller access
- listed under Telecommunications because the API is for SIM lifecycle and network operations