### PR TITLE
Add Simcloud API

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ API | Description | Auth | HTTPS | CORS | Call this API |
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
 | [MTN Developer Portal](https://developers.mtn.com/) | List of product APIs for your business. | `X-API-KEY` | Yes | Unknown | 
+| [Simcloud](https://simcloud.co.za/api/sms.html) | SMS API for sending messages and checking delivery status in South Africa. | `Bearer token` | Yes | No | 
 | [Vodacom Pulse API](https://apipulse.vodacom.co.za/) | List of APIs for your business. | Unknown | Yes | Unknown | |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Summary
- add Simcloud under the Telecommunications section
- link to the public SMS API documentation
- note auth as `Bearer token`, HTTPS as `Yes`, and CORS as `No` based on live response headers

## Notes
- public docs: https://simcloud.co.za/api/sms.html
- base endpoint documented as: https://simcloud.co.za/api/sms.php
- the API supports sending SMS messages and querying delivery status
- requests require a bearer token in the `Authorization` header
- listed under Telecommunications because the API is for SMS delivery operations