### PR TITLE
Add Freepaid Airtime API

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ API | Description | Auth | HTTPS | CORS | Call this API |
 ### Telecommunications
 API | Description | Auth | HTTPS | CORS |
 |---|:---|:---|:---|:---|
+| [Freepaid Airtime](https://freepaid.co.za/airtime-api.php) | SOAP API for South African airtime and data orders, balances, and voucher retrieval. | `user/pass` | Yes | No | 
 | [MTN Developer Portal](https://developers.mtn.com/) | List of product APIs for your business. | `X-API-KEY` | Yes | Unknown | 
 | [Vodacom Pulse API](https://apipulse.vodacom.co.za/) | List of APIs for your business. | Unknown | Yes | Unknown | |
 


### PR DESCRIPTION
## Summary
- add Freepaid Airtime under the Telecommunications section
- link to the public airtime API documentation page
- note auth as `user/pass`, HTTPS as `Yes`, and CORS as `No` based on live response headers

## Notes
- public docs: https://freepaid.co.za/airtime-api.php
- SOAP endpoint/WSDL: https://ws.freepaid.co.za/airtimeplus/?wsdl
- the API documents airtime/data ordering, balance checks, product fetches, and order retrieval
- requests require a registered account user number and password
- listed under Telecommunications because the API is for airtime/data and voucher fulfilment operations